### PR TITLE
Add sage templates import-lnw for legacy SNID templates

### DIFF
--- a/snid_sage/interfaces/cli/main.py
+++ b/snid_sage/interfaces/cli/main.py
@@ -20,6 +20,7 @@ from snid_sage.snid.snid import run_snid
 import snid_sage.interfaces.cli.identify as identify_module
 import snid_sage.interfaces.cli.batch as batch_module
 import snid_sage.interfaces.cli.config as config_module
+import snid_sage.interfaces.cli.templates as templates_module
 from snid_sage.shared.utils.logging import add_logging_arguments, configure_from_args
 from snid_sage.shared.utils.logging import VerbosityLevel
 
@@ -110,7 +111,15 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     config_module.add_arguments(config_parser)
-    
+
+    # Templates management commands
+    templates_parser = subparsers.add_parser(
+        "templates",
+        help="Manage template libraries (import, convert)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    templates_module.add_arguments(templates_parser)
+
     return parser
 
 
@@ -132,7 +141,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     #   - sage --profile onir <file>
     # We insert 'identify' just before the first non-option token,
     # so global options (e.g. verbosity) remain in the global scope.
-    known_commands = {'identify', 'batch', 'config'}
+    known_commands = {'identify', 'batch', 'config', 'templates'}
     has_command = any(tok in known_commands for tok in argv)
     if not has_command:
         # Partition argv into known global options vs the rest, then insert 'identify'
@@ -184,6 +193,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             return batch_module.main(args)
         elif args.command == "config":
             return config_module.main(args)
+        elif args.command == "templates":
+            return templates_module.main(args)
         else:
             parser.print_help()
             return 0

--- a/snid_sage/interfaces/cli/templates.py
+++ b/snid_sage/interfaces/cli/templates.py
@@ -2,14 +2,18 @@
 CLI: Templates Subcommands
 ==========================
 
-Add CSV-based bulk import for templates with multi-epoch support.
+Commands for managing SNID template libraries, including import from
+legacy SNID .lnw format and CSV-based bulk import.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
+import time
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -18,6 +22,17 @@ import numpy as np
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     sub = parser.add_subparsers(dest="templates_cmd")
+
+    # import-lnw: convert a directory of .lnw files to HDF5 storage
+    lnw = sub.add_parser(
+        "import-lnw",
+        help="Convert a directory of legacy SNID .lnw templates to HDF5 format",
+    )
+    lnw.add_argument("source_dir", help="Directory containing .lnw template files")
+    lnw.add_argument(
+        "-o", "--output",
+        help="Output directory for HDF5 files (default: source_dir)",
+    )
 
     imp = sub.add_parser("import-csv", help="Import templates in bulk from a CSV/TSV file")
     imp.add_argument("file", help="Path to CSV/TSV file with spectra list")
@@ -35,9 +50,184 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     imp.add_argument("--default-redshift", type=float, default=0.0)
 
 
+def _import_lnw(args: argparse.Namespace) -> int:
+    """Convert a directory of .lnw templates to SNID-SAGE HDF5 format."""
+    import h5py
+    from snid_sage.snid.io import read_template
+    from snid_sage.snid.preprocessing import log_rebin, init_wavelength_grid
+
+    src = Path(args.source_dir)
+    if not src.is_dir():
+        print(f"[ERROR] Not a directory: {src}")
+        return 1
+
+    lnw_files = sorted(src.glob("*.lnw"))
+    if not lnw_files:
+        print(f"[ERROR] No .lnw files found in {src}")
+        return 1
+
+    out = Path(args.output) if args.output else src
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Standard optical grid parameters
+    NW = 1024
+    W0 = 2500.0
+    W1 = 10000.0
+    init_wavelength_grid(num_points=NW, min_wave=W0, max_wave=W1)
+    DWLOG = np.log(W1 / W0) / NW
+    standard_log_wave = W0 * np.exp((np.arange(NW) + 0.5) * DWLOG)
+
+    print(f"Reading {len(lnw_files)} .lnw files from {src} ...")
+
+    templates_by_type: Dict[str, list] = defaultdict(list)
+    seen_names: set = set()
+    skipped = 0
+    total_epochs = 0
+
+    for lnw_file in lnw_files:
+        try:
+            tpl = read_template(str(lnw_file))
+        except Exception as e:
+            print(f"  [WARN] Skipping {lnw_file.name}: {e}")
+            skipped += 1
+            continue
+
+        sn_type = tpl.get("type", "Unknown")
+        subtype = tpl.get("subtype", "Unknown")
+        name = tpl["name"]
+        nepoch = tpl.get("nepoch", 1)
+        ages = tpl.get("ages", [0.0])
+        wave = tpl["wave"]  # already Angstroms
+        flux_matrix = tpl.get("flux_matrix", tpl["flux"].reshape(1, -1))
+
+        for epoch_idx in range(nepoch):
+            epoch_age = ages[epoch_idx] if epoch_idx < len(ages) else 0.0
+            if epoch_age == -999.0:
+                continue
+
+            epoch_flux = flux_matrix[epoch_idx]
+            try:
+                _, rebinned_flux = log_rebin(wave, epoch_flux)
+            except Exception:
+                continue
+            if len(rebinned_flux) != NW:
+                continue
+
+            fft = np.fft.fft(rebinned_flux)
+
+            # Build unique epoch name
+            if nepoch > 1:
+                epoch_name = f"{name}_ep{epoch_idx}_age{epoch_age:+.1f}"
+            else:
+                epoch_name = name
+            base = epoch_name
+            counter = 1
+            while epoch_name in seen_names:
+                epoch_name = f"{base}_{counter}"
+                counter += 1
+            seen_names.add(epoch_name)
+
+            templates_by_type[sn_type].append({
+                "name": epoch_name,
+                "type": sn_type,
+                "subtype": subtype,
+                "age": epoch_age,
+                "redshift": tpl.get("delta", 0.0),
+                "flux": rebinned_flux,
+                "fft": fft,
+            })
+            total_epochs += 1
+
+    if total_epochs == 0:
+        print("[ERROR] No valid template epochs extracted.")
+        return 1
+
+    print(f"Converted {total_epochs} template epochs across {len(templates_by_type)} types"
+          + (f" (skipped {skipped} files)" if skipped else ""))
+    for t, entries in sorted(templates_by_type.items()):
+        print(f"  {t}: {len(entries)}")
+
+    # Write HDF5 files per type
+    for sn_type, entries in templates_by_type.items():
+        safe_type = sn_type.replace("/", "_").replace("-", "_").replace(" ", "_")
+        h5_path = out / f"templates_{safe_type}.hdf5"
+
+        with h5py.File(h5_path, "w") as f:
+            meta = f.create_group("metadata")
+            meta.attrs["version"] = "2.0"
+            meta.attrs["created_date"] = time.time()
+            meta.attrs["template_count"] = len(entries)
+            meta.attrs["supernova_type"] = sn_type
+            meta.attrs["grid_rebinned"] = True
+            meta.attrs["NW"] = NW
+            meta.attrs["W0"] = W0
+            meta.attrs["W1"] = W1
+            meta.attrs["DWLOG"] = DWLOG
+            meta.attrs["profile_id"] = "optical"
+            meta.create_dataset("standard_wavelength", data=standard_log_wave)
+
+            tpl_group = f.create_group("templates")
+            for entry in entries:
+                g = tpl_group.create_group(entry["name"])
+                g.create_dataset("flux", data=entry["flux"])
+                g.create_dataset("fft_real", data=entry["fft"].real)
+                g.create_dataset("fft_imag", data=entry["fft"].imag)
+                g.attrs["type"] = entry["type"]
+                g.attrs["subtype"] = entry["subtype"]
+                g.attrs["age"] = entry["age"]
+                g.attrs["redshift"] = entry["redshift"]
+                g.attrs["epochs"] = 1
+                g.attrs["rebinned"] = True
+
+        print(f"  Wrote {h5_path.name} ({len(entries)} templates)")
+
+    # Write template_index.json
+    index: Dict[str, Any] = {
+        "version": "2.0",
+        "created_date": time.time(),
+        "template_count": total_epochs,
+        "grid_rebinned": True,
+        "grid_params": {"NW": NW, "W0": W0, "W1": W1, "DWLOG": DWLOG},
+        "profile_id": "optical",
+        "templates": {},
+        "by_type": {},
+    }
+    for sn_type, entries in templates_by_type.items():
+        safe_type = sn_type.replace("/", "_").replace("-", "_").replace(" ", "_")
+        storage_file = f"templates_{safe_type}.hdf5"
+        type_info: Dict[str, Any] = {
+            "count": len(entries),
+            "storage_file": storage_file,
+            "template_names": [],
+        }
+        for entry in entries:
+            index["templates"][entry["name"]] = {
+                "type": entry["type"],
+                "subtype": entry["subtype"],
+                "redshift": entry["redshift"],
+                "epochs": 1,
+                "storage_file": storage_file,
+            }
+            type_info["template_names"].append(entry["name"])
+        index["by_type"][sn_type] = type_info
+
+    index_path = out / "template_index.json"
+    with open(index_path, "w") as f:
+        json.dump(index, f, indent=2)
+
+    print(f"\nDone! {total_epochs} templates -> {out}")
+    print(f"Use with:  sage identify <spectrum> {out}")
+    return 0
+
+
 def main(args: argparse.Namespace) -> int:
-    if getattr(args, "templates_cmd", None) != "import-csv":
-        print("No templates subcommand selected.")
+    cmd = getattr(args, "templates_cmd", None)
+
+    if cmd == "import-lnw":
+        return _import_lnw(args)
+
+    if cmd != "import-csv":
+        print("No templates subcommand selected. Use 'import-lnw' or 'import-csv'.")
         return 1
 
     file_path = Path(args.file)


### PR DESCRIPTION
## Summary
- Add `sage templates import-lnw <dir> [-o output]` command to convert legacy SNID .lnw template files into SNID-SAGE HDF5 format
- Reads all .lnw files, splits multi-epoch templates into individual entries, filters out -999 age epochs, rebins to the standard 1024-point optical grid, pre-computes FFTs, and writes per-type HDF5 files with `template_index.json`
- Also wires up the existing `templates` subcommand (including `import-csv`) which was defined in `templates.py` but never registered in the CLI dispatcher

## Example usage
```bash
# Convert legacy SNID templates-2.0
sage templates import-lnw /path/to/templates-2.0 -o /tmp/my-templates

# Use them for analysis
sage identify spectrum.dat /tmp/my-templates
```

## Test plan
- [x] Tested with SNID templates-2.0 (349 .lnw files -> 3760 template epochs across 7 types)
- [x] Verified converted templates produce correct classification results (Ia-norm, z=0.5309±0.0041)
- [x] Results consistent with built-in template analysis
- [x] `sage templates import-lnw --help` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)